### PR TITLE
expose exclude config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You can either configure the TSLint extension using a `tsconfig` or `jsconfig` a
 
  * `tslint.ignoreDefinitionFiles` - Control if TypeScript definition files should be ignored. Default is `true`.
 
+ * `tslint.exclude` - A glob or an array of globs. Any file matching these globs will not be linted.
+
  * `tslint.alwaysShowRuleFailuresAsWarnings` - Always show rule failures as warnings, ignoring the severity configuration in the tslint.json configuration.
 
  * `tslint.suppressWhileTypeErrorsPresent` - Suppress tslint errors from being reported while other errors are present.

--- a/package.json
+++ b/package.json
@@ -122,6 +122,20 @@
                     "type": "boolean",
                     "description": "Control if TypeScript definition files should be ignored."
                 },
+                "tslint.exclude": {
+                    "description": "A glob or an array of globs. Any file matching these globs will not be linted.",
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
                 "tslint.alwaysShowRuleFailuresAsWarnings": {
                     "type": "boolean",
                     "description": "Always show rule failures as warnings, independent of the tslint configuration."

--- a/schemas/tsconfig.schema.json
+++ b/schemas/tsconfig.schema.json
@@ -37,6 +37,20 @@
                                     "default": true,
                                     "description": "Control if TypeScript definition files should be ignored. Default is `true`."
                                 },
+                                "exclude": {
+                                    "description": "A glob or an array of globs. Any file matching these globs will not be linted.",
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "alwaysShowRuleFailuresAsWarnings": {
                                     "type": "boolean",
                                     "default": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ interface SynchronizedConfiguration {
     configFile?: string;
     suppressWhileTypeErrorsPresent?: boolean;
     jsEnable?: boolean;
+    exclude?: string | string[];
 }
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -49,6 +50,7 @@ function getConfiguration(): SynchronizedConfiguration {
     withConfigValue<boolean>(config, 'suppressWhileTypeErrorsPresent', value => { outConfig.suppressWhileTypeErrorsPresent = value; });
     withConfigValue<boolean>(config, 'jsEnable', value => { outConfig.jsEnable = value; });
     withConfigValue<string>(config, 'configFile', value => { outConfig.configFile = value; });
+    withConfigValue<string | string[]>(config, 'exclude', value => { outConfig.exclude = value; });
 
     return outConfig;
 }


### PR DESCRIPTION
Goes together with https://github.com/Microsoft/typescript-tslint-plugin/pull/39.
My main use case is to be able to globally exclude "node_modules".