### PR TITLE
Add basic tslint.autoFixOnSave support (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ You can either configure the TSLint extension using a `tsconfig` or `jsconfig` a
 
  * `tslint.suppressWhileTypeErrorsPresent` - Suppress tslint errors from being reported while other errors are present.
 
+ * `tslint.autoFixOnSave` - turns auto fix on save on or off. **Note:** Auto-fixing is only done when manually saving a file. It is not performed when the file is automatically saved based on the `files.autoSave` setting. Executing a manual save on an already-saved document will trigger auto-fixing.
+
 
 ## Differences with the [vscode-TSLint][vscode-tslint] extension
 

--- a/package.json
+++ b/package.json
@@ -144,6 +144,12 @@
                 "tslint.suppressWhileTypeErrorsPresent": {
                     "type": "boolean",
                     "description": "Always show rule failures as warnings, independent of the tslint configuration."
+                },
+                "tslint.autoFixOnSave": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Turns auto fix on save on or off.",
+                    "scope": "resource"
                 }
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,18 +49,22 @@ function getConfiguration(): SynchronizedConfiguration {
     const config = vscode.workspace.getConfiguration(configurationSection);
     const outConfig: SynchronizedConfiguration = {};
 
-    withConfigValue<boolean>(config, 'alwaysShowRuleFailuresAsWarnings', value => { outConfig.alwaysShowRuleFailuresAsWarnings = value; });
-    withConfigValue<boolean>(config, 'ignoreDefinitionFiles', value => { outConfig.ignoreDefinitionFiles = value; });
-    withConfigValue<boolean>(config, 'suppressWhileTypeErrorsPresent', value => { outConfig.suppressWhileTypeErrorsPresent = value; });
-    withConfigValue<boolean>(config, 'jsEnable', value => { outConfig.jsEnable = value; });
-    withConfigValue<string>(config, 'configFile', value => { outConfig.configFile = value; });
-    withConfigValue<string | string[]>(config, 'exclude', value => { outConfig.exclude = value; });
+    withConfigValue(config, outConfig, 'alwaysShowRuleFailuresAsWarnings');
+    withConfigValue(config, outConfig, 'ignoreDefinitionFiles');
+    withConfigValue(config, outConfig, 'suppressWhileTypeErrorsPresent');
+    withConfigValue(config, outConfig, 'jsEnable');
+    withConfigValue(config, outConfig, 'configFile');
+    withConfigValue(config, outConfig, 'exclude');
 
     return outConfig;
 }
 
-function withConfigValue<T>(config: vscode.WorkspaceConfiguration, key: string, withValue: (value: T) => void): void {
-    const configSetting = config.inspect(key);
+function withConfigValue<C, K extends Extract<keyof C, string>>(
+    config: vscode.WorkspaceConfiguration,
+    outConfig: C,
+    key: K,
+): void {
+    const configSetting = config.inspect<C[K]>(key);
     if (!configSetting) {
         return;
     }
@@ -71,9 +75,9 @@ function withConfigValue<T>(config: vscode.WorkspaceConfiguration, key: string, 
         return;
     }
 
-    const value = config.get<T | undefined>(key, undefined);
+    const value = config.get<vscode.WorkspaceConfiguration[K] | undefined>(key, undefined);
     if (typeof value !== 'undefined') {
-        withValue(value);
+        outConfig[key] = value;
     }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,53 @@
+import { CodeAction, Command, commands, languages, Range, TextDocument, TextEdit, Uri, window, workspace } from 'vscode';
+
+export function isTypeScriptDocument(document: TextDocument) {
+    return document.languageId === 'typescript' || document.languageId === 'typescriptreact';
+}
+
+export function isJavaScriptDocument(languageId: string) {
+    return languageId === 'javascript' || languageId === 'javascriptreact';
+}
+
+export function isEnabledForJavaScriptDocument(document: TextDocument) {
+    let isJsEnable = workspace.getConfiguration('tslint', document.uri).get('jsEnable', true);
+    if (isJsEnable && isJavaScriptDocument(document.languageId)) {
+        return true;
+    }
+    return false;
+}
+
+function executeCodeActionProvider(uri: Uri, range: Range) {
+    return commands.executeCommand<(CodeAction | Command)[]>('vscode.executeCodeActionProvider', uri, range);
+}
+
+export async function fixAll(document: TextDocument) {
+    const diagnostics = languages
+        .getDiagnostics(document.uri)
+        .filter(diagnostic => diagnostic.source === 'tslint');
+
+    for (let diagnostic of diagnostics) {
+        const codeActions = await executeCodeActionProvider(
+            document.uri,
+            diagnostic.range
+        );
+        if (codeActions) {
+            const fixAll = codeActions.filter(
+                ({ title }) => title === 'Fix all auto-fixable tslint failures'
+            );
+            if (fixAll.length) {
+                const codeActionOrCommand = fixAll[0];
+                if (codeActionOrCommand instanceof CodeAction) {
+                    if (codeActionOrCommand.edit) {
+                        await workspace.applyEdit(codeActionOrCommand.edit);
+                    }
+                }
+                const command = codeActionOrCommand instanceof CodeAction ? codeActionOrCommand.command : codeActionOrCommand;
+                if (command) {
+                    const args = ('arguments' in command) ? command.arguments || [] : [];
+                    await commands.executeCommand(command.command, ...args);
+                }
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request replicates the basic boolean version of `tslint.autoFixOnSave` config option of [vscode-tslint](https://github.com/Microsoft/vscode-tslint) extension. 

Quite ugly solution which finds the code action having the exact 'Fix all auto-fixable tslint failures' title. As I understand the current API does not allow a more sophisticated solution, but I am open for implementing other proposal if you have one. At least this one is working now. I have opened a PR in https://github.com/Microsoft/typescript-tslint-plugin/pull/46, if accepted, there will be a nicer solution and will be possible to implement the array version of `tslint.autoFixOnSave` option too.

Related issues:

 - #2 
 - https://github.com/Microsoft/vscode-tslint/issues/417
