### PR TITLE
Improves documentation about new typescript version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please refer to the [tslint documentation](https://github.com/palantir/tslint) f
 
 ## Usage
 
-> ❗ **Important**: If you also have the [vscode-tslint][vscode-tslint] extension in VS Code installed, please disable it to avoid linting files twice.*
+> ❗ **Important**: This now only supports projects using TypeScript **3.2.0 or newer**. You may enable the deprecated [vscode-TSLint][vscode-tslint] extension for projects using older versions of TypeScript, but please [disable one of the extensions][disable-extension] in your workspaces to avoid linting files twice.
 
 This extension works using VS Code's built-in version of TypeScript and a local or global install of tslint. You do not need to configure the plugin in your `tsconfig.json` if you are using VS Code's version of TypeScript.
 
@@ -14,7 +14,7 @@ If you are using VS Code 1.30 or older and are [using a workspace version of typ
 
 ## Configuration
 
-You can either configure the TSLint extension using a `tsconfig` or `jsconfig` as described [here][configuration], or configure it with VS Code settings. This requires VS Code 1.30+ and TS 3.2+. Note the VS Code based configuration overrides the `tsconfig` or `jsconfig` configuration.
+You can either configure the TSLint extension using a `tsconfig` or `jsconfig` as described [here][configuration], or configure it with VS Code settings. Note the VS Code based configuration overrides the `tsconfig` or `jsconfig` configuration.
 
  * `tslint.configFile` - The configuration file that tslint should use instead of the default tslint.json. A relative file path is resolved relative to the project root.
 
@@ -61,5 +61,8 @@ You can also setup a keybinding for tslint auto fix:
 
 - `vscode-tslint` can only lint one file a time. It therefore cannot support [semantic tslint rules](https://palantir.github.io/tslint/usage/type-checking/) that require the type checker. The language service plugin doesn't have this limitation. To overcome this limitation is a key motivation for reimplementing the extension.
 
+- This implementation supports newer versions of TypeScript.
+
 [vscode-tslint]: https://marketplace.visualstudio.com/items?itemName=eg2.tslint
 [configuration]: https://github.com/Microsoft/typescript-tslint-plugin#configuration-options
+[disable-extension]: https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension


### PR DESCRIPTION
As a current extension user :wave:, when the extension updates and breaks compatibility with older versions of TypeScript, I should be able to clearly see the new requirement after the extension automatically updates. I am less likely to look in Configuration because I have already configured the extension.

It took much issue searching trying to figure out how to debug why tslint no longer was working (reading through #54, #72, #61). I did look at the extension page, but I did not seem to notice the new requirement. Eventually I was able to enable verbose logging, see that `typescript-tslint-plugin` had a [cryptic (now clear) version requirement for TypeScript](https://github.com/Microsoft/typescript-tslint-plugin/commit/e0448747377c64ecc57765a73316b00c372ef630), and realize that I can no longer use the extension for all my projects. Finally, I did find the "TS 3.2+" mentioned in the Configuration section. 

I took a stab at improving the documentation.

I wasn't sure whether to combine the current "important" notice or not, but I ended up doing so trying to write concisely that a user can both use this extension on newer projects and explicitly disable it and enable the deprecated extension on older projects. I couldn't find the best documentation page to link to to explain the "Enable/Disable (Workspace)" option.

Hopefully it makes it clearer, sooner, when looking at the extension page. :-)

As a follow-up, there might be a way to look for the version requirement in typescript-tslint-plugin and then report that directly to the user without logging it to a file.
