### PR TITLE
Fix #93

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
             },
             {
                 "name": "tslint5",
-                "regexp": "^(WARNING|ERROR):(\\s+\\(\\S*\\))?\\s+(\\S.*)\\[(\\d+), (\\d+)\\]:\\s+(.*)$",
+                "regexp": "^(WARNING|ERROR):(\\s+\\(\\S*\\))?\\s+(\\S.*)(:|\\[)(\\d+)(:|, )(\\d+)(\\]:\\s+|\\s+-\\s+)(.*)$",
                 "severity": 1,
                 "file": 3,
-                "line": 4,
-                "column": 5,
-                "message": 6
+                "line": 5,
+                "column": 7,
+                "message": 9
             }
         ],
         "problemMatchers": [


### PR DESCRIPTION
Update the tslint5 problemPattern to also match problems reported by tslint >= 5.12

The used regex can be tested [here](https://regex101.com/r/d3Fsea/1)

Fix #93 