### PR TITLE
Revert "Use find": Fixes scenarios where "fix all" doesn't fix anything

### DIFF
--- a/src/fixAll.ts
+++ b/src/fixAll.ts
@@ -15,7 +15,10 @@ async function getTsLintFixAllCodeAction(document: vscode.TextDocument): Promise
     for (const diagnostic of diagnostics) {
         const codeActions = await executeCodeActionProvider(document.uri, diagnostic.range);
         if (codeActions) {
-            return codeActions.find(action => action.title === 'Fix all auto-fixable tslint failures');
+            const fixAll = codeActions.filter(action => action.title === 'Fix all auto-fixable tslint failures');
+            if (fixAll.length > 0) {
+                return fixAll[0];
+            }
         }
     }
     return undefined;


### PR DESCRIPTION
#### Take the following scenario:
- There are multiple `tslint` diagnostics in the document.
- The first diagnostic has code actions but none have the expected title `Fix all auto-fixable tslint failures` (for example, it has one code action just for `Disable rule 'ordered-imports'`)
- A later diagnostic **does** have a code action that has `Fix all auto-fixable tslint failures` (there may be a separate but unrelated issue at play: *why* does the first `tslint` diagnostic not have that code action?)

#### Current problem
With the change to `find`, this block will short-circuit and return `undefined` when processing the first `tslint` diagnostic without any matching code actions. This means that it will not end up checking the later `tslint` diagnostics that *do* have the expected code action. And then since this returns `undefined`, nothing ends up fixed.

This pull request reverts that change to `.find`, going back to the `.filter` logic that correctly proceeded to check further diagnostics when no matching code actions are found.

#### Potentially related issues
#76