### PR TITLE
Fix #95

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
             {
                 "name": "tslint4",
                 "label": "tslint (version 4) warnings",
-                "owner": "tslint",
+                "owner": "typescript",
                 "source": "tslint",
                 "applyTo": "closedDocuments",
                 "fileLocation": "absolute",
@@ -84,7 +84,7 @@
             },
             {
                 "name": "tslint5",
-                "owner": "tslint",
+                "owner": "typescript",
                 "source": "tslint",
                 "label": "tslint (version 5) warnings",
                 "applyTo": "closedDocuments",


### PR DESCRIPTION
Change problemMatcher.owner from `tslint` to `typescript`.

Since this version of the tslint-plugin is running as a tsserver plugin, the owner of the reported problems is no longer `tslint` but `typescript`.
Using `tslint` as owner in the problemMatchers might result in duplicate errors.

Fix #95